### PR TITLE
게시판 수정 및 토스트 에디터 수정

### DIFF
--- a/.env
+++ b/.env
@@ -7,11 +7,14 @@ VUE_APP_TRAVEL_DETAIL = "/api/trip/agency-trip/"
 VUE_APP_TRAVEL_PAY = "/api/trip/reser/pay/complete"
 VUE_APP_ARTICLE_LIST = "/api/trip/articles"
 VUE_APP_ARTICLE_DETAIL = "/api/trip/articles/"
-<<<<<<< Updated upstream
+VUE_APP_ARTICLE_UPDATE_VALID = "/api/trip/articles/valid/"
 VUE_APP_UPDATE_PERSON = "/api/trip/agency-trip/count/"
-=======
 VUE_APP_ARTICLE_INSERT = "/api/trip/articles/new-article"
 VUE_APP_ARTICLE_COMMENT_INSERT = "/api/trip/articles/comment/new"
 VUE_APP_ARTICLE_COMMENT_LIST = "/api/trip/articles/comment/"
 VUE_APP_ARTICLE_COMMENT_UPDEL = "/api/trip/articles/comment/"
->>>>>>> Stashed changes
+VUE_APP_FILE_UPLOAD = "/api/common/file-upload"
+VUE_APP_FILE_Image = "/api/common/image"
+VUE_APP_EDITOR_IMAGE = "/api/common/image/editor/"
+
+

--- a/src/assets/js/common.js
+++ b/src/assets/js/common.js
@@ -84,5 +84,19 @@ export default{
         Vue.config.globalProperties.$numberWithCommas = function(data) {
             return data.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
         }
+
+        Vue.config.globalProperties.$emptyChk = function(data) {
+            var blank_pattern = /^\s+|\s+$/g;
+            if( data.replace( blank_pattern, '' ) == "" ){
+                return true;
+            }else if( data == "" || 
+                data == null || 
+                data == undefined || 
+                ( data != null && typeof value == "object" && !Object.keys(data).length ) ){
+                return true
+              } else{
+                return false
+              }
+        }
     }
 }

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -148,6 +148,7 @@ export default {
       index : 0,
       chk :false,
       agency_random_list : [],
+      aa:"",
     }
   },
 

--- a/src/components/article/ArticleDetail.vue
+++ b/src/components/article/ArticleDetail.vue
@@ -88,11 +88,15 @@ export default {
                 obj.upd_chk     = false;
                 this.reply.push(obj);
             });
+            if(this.pageTotal==0){
+              this.pageChk = false;
+            }else {
+              this.pageChk = true;
+            }
           }
         }).catch((error) => {
              this.$swal('',error.response.data.result,'error');
         }).finally(() => {
-          this.pageChk = true;
           this.loading = false;
         });
       },
@@ -100,6 +104,7 @@ export default {
       comment_ins(value) {
         if(this.comment_reply_ins==""){
              this.$swal('','댓글을 입력해주세요.','warning');
+             return;
         }
         const headers = {
             'Authorization': 'Bearer ' + localStorage.getItem("token")
@@ -125,7 +130,7 @@ export default {
         this.init();
       },
 
-      comment_upd(value,index) {
+      comment_upd(index) {
         this.reply[index].upd_chk = !this.reply[index].upd_chk
         if(this.reply[index].upd_chk) {
           this.form.new_content[index] = this.reply[index].content;

--- a/src/components/article/ArticleModify.vue
+++ b/src/components/article/ArticleModify.vue
@@ -1,0 +1,102 @@
+<template>
+<div class="input-group mb-3" style="margin-top:1rem;">
+  <input type="text" v-model="title" class="form-control" aria-label="Sizing example input" aria-describedby="inputGroup-sizing-default" placeholder="제목을 입력해주세요.">
+</div>
+    <ToastEditor  v-if="test" @contentChange="editorContent" :content="content"></ToastEditor>
+    <div style="display:flex; justify-content:end;">
+    <button type="button" class="btn btn-primary" @click="regArticle">저장</button>
+    </div>
+<BlackBg v-if="loading"></BlackBg>
+</template>
+
+
+<script>
+
+import ToastEditor from '@/components/editor/ToastModifyEditor.vue'
+import BlackBg from "../loading/BlackBg"
+export default {
+	data: function () {
+    return {
+        articleId:0,
+        contentChange:'',
+        title:"",
+        loading:false,
+        content:"",
+        test:false,
+    }
+  },
+  components :{
+        ToastEditor,
+        BlackBg
+  },
+  created(){
+    this.articleId = this.$route.query.sn;
+    console.log(this.$route.query.sn);
+    this.init();
+  },    
+  methods: {
+    init() {
+            this.validArticle();
+    },
+
+    validArticle() {
+        this.loading = true;
+        const headers = { 'Authorization': 'Bearer ' + localStorage.getItem("token")}
+        this.$axios.get(process.env.VUE_APP_ARTICLE_UPDATE_VALID+this.$route.query.sn,{headers}).then((res) =>{
+         if(res.data.resultCode=="SUCCESS"){
+            this.title = res.data.result.title;
+            this.content = res.data.result.content;
+            console.log(this.content);
+          }
+        }).catch((error) => {
+             this.$swal('',error.response.data.result,'error');
+             this.$router.push("/article");
+        }).finally(() => {
+          this.pageChk = true;
+          this.loading = false;
+          this.test = true;
+        });
+    },
+        editorContent(value){
+            this.contentChange =  value;
+        },
+        regArticle(){
+             const headers = { 'Authorization': 'Bearer ' + localStorage.getItem("token")}
+            var content = this.contentChange;
+            content = content.replace(/&nbsp;/gi,"");
+            content = content.replace(/<br>/gi,"");
+            content = content.replace(/ /gi,"");
+            if(this.$emptyChk(this.title)){
+                this.$swal('','제목을 입력해주세요.','warning');
+                return;
+            }
+            if(content =="<p><\/p>" || content==" "){
+                this.$swal('','내용을 입력해주세요.','warning');
+                return;
+            }
+            
+            let param = {
+                "title"  : this.title ,
+                "content" : this.contentChange
+            }
+            this.loading = true;
+            this.$axios.post(process.env.VUE_APP_ARTICLE_DETAIL+this.articleId+"/form",param,{headers}).then((res) =>{
+                if(res.data.resultCode=="SUCCESS"){
+                    this.$swal('',"저장되었습니다.",'success');
+                        this.$router.push({
+                                    path: "/articleDetail",
+                                    name: "articleDetail",
+                                    query: { sn: this.articleId }
+                                });
+            }
+        }).catch((error) => {
+             this.$swal('',error.response.data.result,'error');
+        }).finally(() => {
+          this.loading = false;
+        });
+        }
+  }
+
+}
+
+</script>

--- a/src/components/article/ArticleWrite.vue
+++ b/src/components/article/ArticleWrite.vue
@@ -37,11 +37,13 @@ export default {
             content = content.replace(/<br>/gi,"");
             content = content.replace(/ /gi,"");
 
-            if(this.title==null || this.title==""){
+            if(this.$emptyChk(this.title)){
                 this.$swal('','제목을 입력해주세요.','warning');
+                return;
             }
             if(content =="<p><\/p>" || content==""){
                 this.$swal('','내용을 입력해주세요.','warning');
+                return;
             }
             
             let param = {

--- a/src/components/editor/ToastModifyEditor.vue
+++ b/src/components/editor/ToastModifyEditor.vue
@@ -7,24 +7,35 @@ import "@toast-ui/editor/dist/toastui-editor.css"; // Editor's Style
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
 import Editor from "@toast-ui/editor";
 // import colorSyntax from '@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css';
-import { ref, onMounted,defineEmits } from "vue";
+import { ref, onMounted,defineEmits,defineProps } from "vue";
 
 const emit =   defineEmits(['contentChange']);
 const refEditor = ref(null); // template의 ref의 값과 동일한 변수 선언
 const axios = require("axios");
+
+
+const props = defineProps({                     
+    content : {
+        type:String,
+        required : true
+    }
+});
+
 onMounted( () => { 
+  console.log(props.content);
    console.log("onMounted")
    const xeditor = new Editor({
     el: refEditor.value,
     height: "500px",
-    initialValue: "",             //init value 
+    initialValue: props.content,             //init value 
     initialEditType: "wysiwyg",
     previewStyle: "tab",
     useDefaultHTMLSanitizer: false,
     language:"ko-KR",
     usageStatistics: false,
     hideModeSwitch: true,   //밑에 창 
-    hooks: {
+    // TODO: 할것
+      hooks: {
     addImageBlobHook: (fileOrBlob, callback) => {
         const headers = {
           "content-type" : "multipart/form-data"

--- a/src/components/editor/ToastViewer.vue
+++ b/src/components/editor/ToastViewer.vue
@@ -16,6 +16,9 @@
 
 <!-- 게시판 -->
 <div v-if="props.contentType=='article'">
+<div class="custom-div" v-if="auth_article">
+  <button class="btn-cl-cus-upd" @click="upd_click">수정</button><button  class="btn-cl-cus-del" @click="delete_click">삭제</button>
+</div>
 <div class="margincustom margintpcust">
     <h2>{{title}}</h2>
 </div>
@@ -38,8 +41,12 @@
 import "@toast-ui/editor/dist/toastui-editor.css"; // Editor's Style
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
 import Viewer from '@toast-ui/editor/dist/toastui-editor-viewer';
-import { ref, onMounted ,defineProps} from "vue";
+import { ref, onMounted ,defineProps,inject} from "vue";
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
 const axios = require("axios");
+const swal = inject('$swal')
  
 //TODO : ARTICLE 값이나 내용 받아서 넣어주면 될거 같다.initialValue의 값을 변경 시켜 주어야 함
 const props = defineProps({                     
@@ -64,6 +71,7 @@ const sale_percent = ref("");
 const sale_paid = ref("");
 const nickname = ref("");
 const created_at = ref("");
+const auth_article = ref("");
 // const emit =   defineEmits(['contentChange']);
 
 function tokenChk() {
@@ -73,6 +81,44 @@ function tokenChk() {
       } 
           return true;
 }
+function delete_click(){
+            swal.fire({
+                        title: '삭제 하시겠습니까?',
+                        text: '다시 되돌릴 수 없습니다.',
+                        icon: 'warning',
+                        showCancelButton: true, // cancel버튼 보이기. 기본은 원래 없음
+                        confirmButtonColor: '#3085d6', // confrim 버튼 색깔 지정
+                        cancelButtonColor: '#d33', // cancel 버튼 색깔 지정
+                        confirmButtonText: '확인', // confirm 버튼 텍스트 지정
+                        cancelButtonText: '취소', // cancel 버튼 텍스트 지정
+                        reverseButtons: true, // 버튼 순서 거꾸로
+   
+      }).then(result => {
+         if (result.isConfirmed) { // 만약 모달창에서 confirm 버튼을 눌렀다면
+             const headers = {
+               'Authorization': 'Bearer ' + localStorage.getItem("token")
+            }
+          axios.put(process.env.VUE_APP_ARTICLE_DETAIL+props.articleId+"/delete",null,{headers}).then((res) =>{
+          if(res.data.resultCode=="SUCCESS"){
+              swal('','삭제되었습니다.','success');
+              router.push("/article");
+          }
+        }).catch(() => {
+           history.back(-1);
+        }).finally(() => {
+        });
+          }
+      });
+}
+
+function upd_click() {
+        router.push({
+          path: "/articleModify",
+          name: "articleModify",
+          query: { sn: props.articleId }
+        });
+}
+
 onMounted( async () => { 
    console.log("onMounted")
   //  console.log(props.articleId);
@@ -103,12 +149,14 @@ onMounted( async () => {
 
 
     await axios.get(process.env.VUE_APP_ARTICLE_DETAIL+props.articleId,tokenChk()==true?{headers}:"").then((res) =>{
+      console.log(res);
           if(res.data.resultCode=="SUCCESS"){
             content              = res.data.result.content;
             title.value          = res.data.result.title;
             nickname.value    = res.data.result.nickName;
             read_count.value     = res.data.result.readCount;
             created_at.value  = res.data.result.createdAt.substr(0,4)+"."+res.data.result.createdAt.substr(5,2)+"."+res.data.result.createdAt.substr(8,2);
+            auth_article.value   = res.data.result.authChk;
             // emit('contentChange',res.data.result.articleCommentResponses);
           }
         }).catch(() => {
@@ -141,6 +189,25 @@ onMounted( async () => {
   }
 .deco{
   text-decoration: line-through;
+}
+.btn-cl-cus-upd {
+    background-color: rgba(0,0,0,0);
+    color: skyblue;
+    border: 0px ;
+    /* width : 15%; */
+    font-size: 13px;
+} 
+.btn-cl-cus-del {
+    background-color: rgba(0,0,0,0);
+    color: red;
+    border: 0px ;
+    /* width : 15%; */
+    font-size: 13px;
+} 
+.custom-div {
+  display: flex;
+  justify-content: end;
+  margin-top:2rem;
 }
 </style>
 

--- a/src/components/login/Join.vue
+++ b/src/components/login/Join.vue
@@ -106,15 +106,15 @@ export default {
           this.alert_chk("비밀번호 를");
           return false;
         }
-        if(this.user_name == null || this.user_name == ""){
+        if(this.$emptyChk(this.user_name)){
             this.alert_chk("이름 을");
             return false;
         }
-        if(this.nick_name == null || this.nick_name == ""){
+        if(this.$emptyChk(this.nick_name)){
             this.alert_chk("닉네임 을");
             return false;
         }
-        if(this.phone_number == null || this.phone_number ==""){
+        if(this.$emptyChk(this.phone_number)){
           this.alert_chk("휴대폰 번호 를");
           return false;
         }
@@ -153,6 +153,7 @@ export default {
       
       alert_chk(value) {
           this.$swal('', value+' 확인해주세요','error');
+          return;
       }
 
   },

--- a/src/components/login/Login.vue
+++ b/src/components/login/Login.vue
@@ -50,11 +50,11 @@ export default {
         this.$router.push("/join");
       },
       login() {
-          if(this.email ==null || this.email == ""){
+          if(this.$emptyChk(this.email)){
                   this.$swal('', "아이디를 입력해주세요.",'waring');
                   return ;
           }
-          if(this.password ==null || this.password == ""){
+          if(this.$emptyChk(this.password)){
                   this.$swal('', "비밀번호를 입력해주세요.",'waring');
                   return ;
           }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -41,6 +41,11 @@ const routes = [
       name: 'articleWrite',
       component: ()=> import('@/components/article/ArticleWrite.vue'),
      },
+     {
+      path: '/articleModify',
+      name: 'articleModify',
+      component: ()=> import('@/components/article/ArticleModify.vue'),
+     },
      
   ],
   },


### PR DESCRIPTION
게시판 수정 로직 완료
및
토스트 에디터에서 지원해주는 첨부파일 이미지 사용을 하게 되면
기본적으로 에디터에 base64로 변환되어 이미지를 주게 된다.
그렇게 되다 보니 파일을 몇장만 올려도 저장이 되지 않고 오류를 뱉게된다.
db 가 (text)이여도 너무많은 양이 들어가서 되지가 않았다.
그래서 방법은 hook을 걸어서 이미지를 base64가 아닌 커스텀을 하여서 콜백을 해주어야 했다.
그래서 방법으로
      hooks: {
    addImageBlobHook: (fileOrBlob, callback) => {
        const headers = {
          "content-type" : "multipart/form-data"
        }
        const formdata = new FormData();
        formdata.append("multiFile",fileOrBlob);
        axios.post(process.env.VUE_APP_FILE_UPLOAD,formdata,{headers}).then((res) =>{
          callback(process.env.VUE_APP_EDITOR_IMAGE+res.data[0].fileId);
        }).catch(() => {
        }).finally(() => {
        });
    },
    },
이 코드를 추가함으로써 여러장의 이미지를 넣어도
디비에는 "/api/common/editor/2" 이 정도의 줄로 들어가서 몇장을 넣어도 된다.